### PR TITLE
authorization_code flow with no offline_access

### DIFF
--- a/main/oauth2_client/credentials_manager.py
+++ b/main/oauth2_client/credentials_manager.py
@@ -135,7 +135,8 @@ class CredentialManager(object):
                 self.authorization_code_context = None
 
     def init_with_authorize_code(self, redirect_uri: str, code: str, **kwargs):
-        self._token_request(self._grant_code_request(code, redirect_uri, **kwargs), True)
+        self._token_request(self._grant_code_request(code, redirect_uri, **kwargs),
+                            "offline_access" in self.service_information.scopes)
 
     def init_with_user_credentials(self, login: str, password: str):
         self._token_request(self._grant_password_request(login, password), True)


### PR DESCRIPTION
The refresh_token is only mandatory for the authorization_code flow if
the offline_access scope is specified. Whilst this is a common scope for
applications using PKCE authorization_code flow, it is not always
needed.