### PR TITLE
Add parameter to override the user agent

### DIFF
--- a/main/oauth2_client/credentials_manager.py
+++ b/main/oauth2_client/credentials_manager.py
@@ -62,9 +62,10 @@ class AuthorizationContext(object):
 
 
 class CredentialManager(object):
-    def __init__(self, service_information: ServiceInformation, proxies: Optional[dict] = None):
+    def __init__(self, service_information: ServiceInformation, proxies: Optional[dict] = None, user_agent: Optional[str] = None):
         self.service_information = service_information
         self.proxies = proxies if proxies is not None else dict(http='', https='')
+        self.user_agent = user_agent
         self.authorization_code_context = None
         self.refresh_token = None
         self._session = None
@@ -221,6 +222,8 @@ class CredentialManager(object):
             self._session.proxies = self.proxies
             self._session.verify = self.service_information.verify
             self._session.trust_env = False
+            if self.user_agent:
+                self._session.headers.update({'User-Agent': self.user_agent})
         if access_token is not None and len(access_token) > 0:
             self._session.headers.update(dict(Authorization='Bearer %s' % access_token))
 

--- a/tests/oauth2_client_tests/test_credential_manager.py
+++ b/tests/oauth2_client_tests/test_credential_manager.py
@@ -288,3 +288,15 @@ class TestManager(unittest.TestCase):
                 self.assertIsNone(manager.refresh_token)
             self.assertEqual(manager._access_token, access_token)
 
+    def test_default_user_agent(self):
+        manager = CredentialManager(service_information, proxies=dict(http=''))
+        manager._access_token = 'a-access-token'
+        self.assertIsNone(manager.user_agent)
+        self.assertIn("python-requests", manager._session.headers["User-Agent"])
+
+    def test_custom_user_agent(self):
+        user_agent = 'custom-agent'
+        manager = CredentialManager(service_information, proxies=dict(http=''), user_agent=user_agent)
+        manager._access_token = 'a-access-token'
+        self.assertEqual(user_agent, manager.user_agent)
+        self.assertEqual(user_agent, manager._session.headers["User-Agent"])


### PR DESCRIPTION
This change allows users to override the default user agent (`python-requests/<version>`) with any string.
I'd like to use this feature in the [cf-python-client](https://github.com/cloudfoundry-community/cf-python-client) so that I can filter CF API logs more easily.